### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to the WESL Specification
+
+Thank you for your interest in contributing to WESL! There are many ways to contribute, and we appreciate all of them.
+
+Everyone is welcome and we strive to be an inclusive and respectful community.
+
+To get started, we recommend introducing yourself on the [WESL Discord Server](https://discord.gg/Ng5FWmHuSv). Then, chat about your proposal in the #spec-general channel.
+
+## Specification Stages
+
+Writing a full specification and getting buy-in in one go is a very challenging task. We recommend breaking it up into smaller chunks, starting with
+
+1. **Open an issue**. Describe your problem and suggest a solution.
+2. Create a pull request with [a **specification proposal**](./proposals/README.md). Proposals have a very low bar for being accepted and anything at this stage is still an experiment.
+3. Create a tracking issue
+4. Optionally **implement it**. This is helpful in revealing hidden complexity and polishing the design.
+5. Create a pull request with **the specification**
+6. **Find consensus**, this part is quite time consuming. We recommend the previous steps to help prepare your specification for this. 
+
+For the specification to be merged, we make sure that all the core spec editors are in agreement.
+Currently these are @stefnotch, @mighdoll, @k2d222. 
+
+Finally, remember that you are invited to ask for assistance at every stage.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,5 @@
+# WESL Specification Proposals
+
+This folder contains proposals for the WESL specification. It is intended as a helpful stepping stone before committing to writing a full specification. 
+
+[CONTRIBUTING.md](../CONTRIBUTING.md) has an overview of the process.


### PR DESCRIPTION
Adds a very basic contributing guide, including the specification stages that we agreed on during our last meeting.

Fix #15 

Should we add a short code of conduct section to the contributing guide or should we add a separate document, similar to https://github.com/wgsl-analyzer/wgsl-analyzer/pull/392 ?