### PR TITLE
Wording tweaks

### DIFF
--- a/ConditionalTranslation.md
+++ b/ConditionalTranslation.md
@@ -3,9 +3,9 @@
 ## Overview
 > *This section is non-normative*
 
-Conditional translation is a mechanism to modify the output source code based on parameters passed to the *WESL translator*.
+Conditional translation is a mechanism to modify the output source code based on parameters passed to the *WESL linker*..
 This specification extends the [*attribute* syntax](https://www.w3.org/TR/WGSL/#attributes) with a new `@if` attribute.
-This attribute indicates that the syntax node it decorates can be removed by the *WESL translator* based on feature flags.
+This attribute indicates that the syntax node it decorates can be removed by the *WESL linker* based on feature flags.
 
 > *This implementation is similar to the `#[cfg(feature = "")]` syntax in Rust.*
 
@@ -49,7 +49,7 @@ const feature1 = 10;
 ```
 
 ## Definitions
-* **Translate-time expression**: A *translate-time expression* is evaluated by the *WESL translator* and eliminated after translation.
+* **Translate-time expression**: A *translate-time expression* is evaluated by the *WESL linker* and eliminated after translation.
   Its grammar is a subset of normal WGSL [expressions](https://www.w3.org/TR/WGSL/#expressions). It must be one of:
   * a *translate-time feature*,
   * a [logical expression](https://www.w3.org/TR/WGSL/#logical-expr): logical not (`!`), short-circuiting AND (`&&`), short-circuiting OR (`||`),
@@ -144,7 +144,7 @@ fn f() { ... }
 
 
 ## Execution of the conditional translation phase
-1. The *WESL translator* is invoked with the list of features to *enable* or *disable*.
+1. The *WESL linker* is invoked with the list of features to *enable* or *disable*.
 
 2. The source file is parsed.
 
@@ -159,13 +159,13 @@ fn f() { ... }
 5. The updated source code is passed to the next translation phase. (e.g. import resolution)
 
 ### Incremental translation
-In case some features can only be resolved at runtime, a *WESL translator* can *optionally* support feature specialization in multiple passes:
+In case some features can only be resolved at runtime, a *WESL linker* can *optionally* support feature specialization in multiple passes:
 
-* In the initial passes, the *WESL translator* is invoked with some of the feature flags. It replaces their occurrences in *translate-time attributes* with either `true` or `false`.
+* In the initial passes, the *WESL linker* is invoked with some of the feature flags. It replaces their occurrences in *translate-time attributes* with either `true` or `false`.
   These passes return a partially-translated WESL code.
 * After the final pass, the resulting code must be valid WGSL. It is a *link-time error* if any used *translate-time feature* was not provided to the linker.
 
-If the *WESL translator* does not support incremental translation, it is a *link-time error* if any used *translate-time feature* was not provided to the linker.
+If the *WESL linker* does not support incremental translation, it is a *link-time error* if any used *translate-time feature* was not provided to the linker.
 
 > *It is not an error to provide unused feature flags to the linker. However, an implementation may choose to display a warning in that case.*
 

--- a/ConditionalTranslation.md
+++ b/ConditionalTranslation.md
@@ -3,7 +3,7 @@
 ## Overview
 > *This section is non-normative*
 
-Conditional translation is a mechanism to modify the output source code based on parameters passed to the *WESL linker*..
+Conditional translation is a mechanism to modify the output source code based on parameters passed to the *WESL linker*.
 This specification extends the [*attribute* syntax](https://www.w3.org/TR/WGSL/#attributes) with a new `@if` attribute.
 This attribute indicates that the syntax node it decorates can be removed by the *WESL linker* based on feature flags.
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -40,4 +40,4 @@
 * **wesl.toml**: The optional configuration file for a package. See [WeslToml](WeslToml.md).
 * **Module Path Resolution**: Mapping between module paths and module source within a package. Choice of mapping is implementation-specific.
 * **Filesystem Resolution**: The default module path resolution. It maps module paths to file paths relative to a **Package Root Directory**. See [Filesystem Resolution][Imports.md#filesystem-resolution].
-* **Package Root Module Path**: The module path consisting only of `package`. Corresponds to `package.wesl` in the package root directory with the filesystem mapping.
+* **Package Root Module Path**: The module path consisting only of `package`. Corresponds to `package.wesl` in the package root directory with the filesystem resolution.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,24 +1,12 @@
 # Glossary of WGSL Importing terms
-* **WESL** - The extended WGSL language, and is pronounced like "weasel". Stands for WebGPU Enhanced Shading Language
-* **WESL translator** - a program that implements the WESL specification
-  and transpiles WESL source code to WGSL.
-* **WESL linker** - a WESL translator.
-  Part of the process of translating WESL involves
-  linking together multiple WGSL and WESL modules.
+
+## General
+
+* **WESL**: The extended WGSL language, and is pronounced like "weasel". Stands for WebGPU Enhanced Shading Language.
+* **WESL linker**: A program that implements the WESL specification and transpiles WESL source code to WGSL.
+  Part of the process of translating WESL involves linking together multiple WGSL and WESL modules.
   Also akin to **bundler** in the JavaScript/TypeScript world.
-* **Importable item**
-  * Structs
-  * Functions
-  * Type aliases
-  * [Const declarations, override declarations](https://www.w3.org/TR/WGSL/#value-decls)
-  * [Var declarations](https://www.w3.org/TR/WGSL/#var-decls)
-* **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
-* **Module Source**: The stored text of a module, typically a WESL or WGSL file.
-* **Root Module**: The WESL module from which translation starts. A single project can have many root modules.
-* **Declaration Path**: A fully qualified `::`-separated path whose final segment names a declared item.
-* **Module Path**: A `::`-separated path naming a module; equivalently, a declaration path minus its final segment. See [Imports](Imports.md#resolving-a-declaration-path).
-* **Import Path**: The `::`-separated path written in an import statement. An import collection (`{}`) flattens into separate imports, each with its own import path.
-* **Package Module**: The top-level module of a package, typically the file `package.wesl` in the package root. A module path consisting only of `package` or a bare package name refers to the package module.
+* **Mangling**: link process in which certain declarations are renamed to avoid name conflicts.
 * **Side effects**: WESL/WGSL shader code that is visible to host code (e.g. in Rust or JavaScript).
   Changes to that shader code have the side effect of changing the host interface to the shader.
   * Things that are specified when [creating a WGSL pipeline](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipeline#fragment_object_structure)
@@ -27,9 +15,29 @@
     * Global variables, including bindings
   * [Directives](https://www.w3.org/TR/WGSL/#directives): Generated WGSL code must agree on a set of directives
   * (Maybe `const_assert`?)
+* **Visibility**: An item's visibility defines which modules can reference or re-export it.
+  Visibility has three levels: `public`, *package* (the default), or `private`.
+  For a pipeline-relevant item, visibility also controls whether the entry module exposes it to the host. see [Visibility](Visibility.md).
+
+## Modules
+
+* **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
+* **Module Source**: The stored text of a module, typically in a WESL or WGSL file.
+* **Entry Module**: The WESL module from which translation starts. Its public declarations form the **shader-host interface** and are not mangled. A single application can have many entry modules.
+* **Module Path**: A `::`-separated path naming a module; equivalently, a declaration path minus its final segment.
+* **Declaration Path**: A `::`-separated path whose final segment names a declared item.
+* **Canonical Path**: A fully qualified module/ declaration path (which does not contain any `super::`). There is exactly one canonical path per module or declaration within a package.
+* **Importable item**: A module declaration or re-export that can be imported by other modules.
+  * Structs
+  * Functions
+  * Type aliases
+  * [Module-scope `const`, `override` and `var` declarations](https://www.w3.org/TR/WGSL/#var-and-value)
+  * Re-exports (aka. public imports)
+
+## Packages
+
 * **Package**: A publishable body of WESL code containing multiple files. Akin to a JavaScript npm package or a Rust crate.
-* **Package Root**: The root directory containing WESL files
-* **Visibility**: Which modules can reference or re-export an item. Visibility
-  has three levels: `public`, *package* (the default), or `private`. For a
-  pipeline-relevant item, visibility also controls whether the root module
-  exposes it to the host (see [Visibility](Visibility.md)).
+* **wesl.toml**: The optional configuration file for a package. See [WeslToml](WeslToml.md).
+* **Module Path Resolution**: Mapping between module paths and module source within a package. Choice of mapping is implementation-specific.
+* **Filesystem Resolution**: The default module path resolution. It maps module paths to file paths relative to a **Package Root Directory**. See [Filesystem Resolution][Imports.md#filesystem-resolution].
+* **Package Root Module Path**: The module path consisting only of `package`. Corresponds to `package.wesl` in the package root directory with the filesystem mapping.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,4 +1,4 @@
-# Glossary of WGSL Importing terms
+# WESL Terms
 
 ## General
 
@@ -17,17 +17,17 @@
   * (Maybe `const_assert`?)
 * **Visibility**: An item's visibility defines which modules can reference or re-export it.
   Visibility has three levels: `public`, *package* (the default), or `private`.
-  For a pipeline-relevant item, visibility also controls whether the entry module exposes it to the host. see [Visibility](Visibility.md).
+  For a pipeline-relevant item, visibility also controls whether the main module exposes it to the host. see [Visibility](Visibility.md).
 
 ## Modules
 
 * **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
 * **Module Source**: The stored text of a module, typically in a WESL or WGSL file.
-* **Entry Module**: The WESL module from which translation starts. Its public declarations form the **shader-host interface** and are not mangled. A single application can have many entry modules.
+* **Main module**: The WESL module from which translation starts. It defines the **pipeline-visible API**, i.e. the set of items which are visible to the host (CPU-side), and therefore are not mangled. A single application can have many main modules.
 * **Module Path**: A `::`-separated path naming a module; equivalently, a declaration path minus its final segment.
 * **Declaration Path**: A `::`-separated path whose final segment names a declared item.
 * **Canonical Path**: A fully qualified module/ declaration path (which does not contain any `super::`). There is exactly one canonical path per module or declaration within a package.
-* **Importable item**: A module declaration or re-export that can be imported by other modules.
+* **Importable item**: Items that can be imported by other modules.
   * Structs
   * Functions
   * Type aliases
@@ -38,6 +38,6 @@
 
 * **Package**: A publishable body of WESL code containing multiple files. Akin to a JavaScript npm package or a Rust crate.
 * **wesl.toml**: The optional configuration file for a package. See [WeslToml](WeslToml.md).
-* **Module Path Resolution**: Mapping between module paths and module source within a package. Choice of mapping is implementation-specific.
-* **Filesystem Resolution**: The default module path resolution. It maps module paths to file paths relative to a **Package Root Directory**. See [Filesystem Resolution][Imports.md#filesystem-resolution].
-* **Package Root Module Path**: The module path consisting only of `package`. Corresponds to `package.wesl` in the package root directory with the filesystem resolution.
+* **Module Path Resolution**: Mapping between module paths and module source within a package. Choice of mapping is specific to the storage type (filesystem, in-memory source, URL-based, etc.).
+* **Filesystem Resolution**: The standard path resolution for a filesystem storage. It maps module paths to file paths relative to a **Package Root Directory**. See [Filesystem Resolution](Imports.md#filesystem-resolution).
+* **Package Root Module Path**: The module path consisting only of `package`. With the filesystem resolution, it is mapped to an optional `package.wesl` file in the package root directory.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -17,15 +17,15 @@
   * (Maybe `const_assert`?)
 * **Visibility**: An item's visibility defines which modules can reference or re-export it.
   Visibility has three levels: `public`, *package* (the default), or `private`.
-  For a pipeline-relevant item, visibility also controls whether the main module exposes it to the host. see [Visibility](Visibility.md).
+  For a pipeline-relevant item, visibility also controls whether the main module exposes it to the host. See [Visibility](Visibility.md).
 
 ## Modules
 
 * **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
 * **Module Source**: The stored text of a module, typically in a WESL or WGSL file.
 * **Main module**: The WESL module from which translation starts. It defines the Pipeline-visible API. A single application can have many main modules.
-* **Pipeline-visible API**, The set of items which are visible to the host (CPU-side). Pipeline-visible item names are not mangled.
-* **Import Path**: A `::`-separated path written in an import statement or inline import. It may start with `super::` segments. In import statements, it may be suffixed with an import collection (`{}`), which flattens into separate imports paths.
+* **Pipeline-visible API**: The set of items which are visible to the host (CPU-side). Pipeline-visible item names are not mangled.
+* **Path**: A `::`-separated path written in an import statement or inline import. It may start with `super::` segments. In import statements, it may be suffixed with an import collection (`{}`), which flattens into separate imports paths.
 * **Canonical Path**: The unique fully qualified import path naming a module or declaration. It does not contain `super::`. import paths can be canonicalized.
 * **Module Path**: A canonical path naming a module; equivalently, a declaration path minus its final segment.
 * **Declaration Path**: A canonical path whose final segment names a declared item.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -23,10 +23,12 @@
 
 * **Module**: A unit of WESL or WGSL code with its own top-level scope, stored in a single module source.
 * **Module Source**: The stored text of a module, typically in a WESL or WGSL file.
-* **Main module**: The WESL module from which translation starts. It defines the **pipeline-visible API**, i.e. the set of items which are visible to the host (CPU-side), and therefore are not mangled. A single application can have many main modules.
-* **Module Path**: A `::`-separated path naming a module; equivalently, a declaration path minus its final segment.
-* **Declaration Path**: A `::`-separated path whose final segment names a declared item.
-* **Canonical Path**: A fully qualified module/ declaration path (which does not contain any `super::`). There is exactly one canonical path per module or declaration within a package.
+* **Main module**: The WESL module from which translation starts. It defines the Pipeline-visible API. A single application can have many main modules.
+* **Pipeline-visible API**, The set of items which are visible to the host (CPU-side). Pipeline-visible item names are not mangled.
+* **Import Path**: A `::`-separated path written in an import statement or inline import. It may start with `super::` segments. In import statements, it may be suffixed with an import collection (`{}`), which flattens into separate imports paths.
+* **Canonical Path**: The unique fully qualified import path naming a module or declaration. It does not contain `super::`. import paths can be canonicalized.
+* **Module Path**: A canonical path naming a module; equivalently, a declaration path minus its final segment.
+* **Declaration Path**: A canonical path whose final segment names a declared item.
 * **Importable item**: Items that can be imported by other modules.
   * Structs
   * Functions

--- a/Imports.md
+++ b/Imports.md
@@ -272,8 +272,9 @@ shown).
 
 ## The package root module
 
-The *package root module* is the optional module which the bare `package`
-module path maps to.
+The *package root module* is the optional module that the bare `package`
+module path maps to. In filesystem resolution, it corresponds to a special file
+named `package.json` in the package root directory.
 
 A declaration `foo` in the package root module is addressable from outside the
 package as `my_pkg::foo`, and from within the package as `package::foo`.
@@ -284,14 +285,52 @@ module named `package` anywhere else.
 ## Filesystem Resolution
 
 On a filesystem, a module path maps directly to a single file, following
-[Resolving a declaration path](#resolving-a-declaration-path). The first
-segment corresponds to the
-package's root directory, each intermediate segment names a subdirectory, and
-the last segment names the module's `.wesl` file (or `.wgsl` when no `.wesl`
-file exists).
+[Resolving a declaration path](#resolving-a-declaration-path).
 
-WESL tools typically find the package's root directory from
-[`wesl.toml`](WeslToml.md#root-field) or from the host package manager.
+The resolution starts with a filesystem root directory, typically in a
+[`wesl.toml`](WeslToml.md#root-field) file, user-provided through the linker's API,
+or defaulted by the linker.
+
+> [!NOTE]
+> Linkers may apply heuristics to find the default filesystem root directory, such as
+> looking for a `shaders` directory at the project root, or using the parent directory
+> of the main module.
+
+The package root module path is mapped to a file named `package.wesl` or `package.wgsl`
+in the package root directory.
+
+Other module paths are mapped as follows: each intermediate segment after `package`
+ name a subdirectory from the package root directory, and the last segment names
+a `.wesl` or `.wgsl` file within the subdirectory.
+
+The `.wesl` extension takes priority over `.wgsl` in case both files are present.
+The extension has no other impact in the translation process.
+A resolution fails if neither `.wesl` nor `.wgsl` file exists for a given module path.
+
+**Example**:
+
+Suppose the following project structure, and the package root directory set to `shaders/`:
+
+```
+src/
+shaders/
+  util/
+    noise.wesl
+  package.wesl
+  main.wesl
+  util.wgsl
+  data.txt
+package.json
+```
+
+The filesystem resolution maps:
+
+* `package` to `shaders/package.wesl`
+* `package::main` to `shaders/main.wesl`
+* `package::util` to `shaders/package/util.wgsl`
+* `package::util::noise` to `shaders/package/util/noise.wesl`
+* `package::data` is an invalid module path, because there is no file named
+  `data.wesl` or `data.wgsl` in `shaders/`.
 
 ### Reserved file names
 
@@ -607,7 +646,7 @@ shadowing.
 Under discussion, see: <https://github.com/webgpu-tools/wesl-spec/issues/71>
 
 ## Side-effects and `const_assert`
-Generally, WGSL elements are included if they are recursively used from the entry module ([statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed)).
+Generally, WGSL elements are included if they are recursively used from the main module ([statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed)).
 An import statement by itself doesn't have any side effects. It does not bring in `const_assert`s.
 
 `const_assert` statements are also included if they are in the same module or namespace as a used element.

--- a/Imports.md
+++ b/Imports.md
@@ -607,7 +607,7 @@ shadowing.
 Under discussion, see: <https://github.com/webgpu-tools/wesl-spec/issues/71>
 
 ## Side-effects and `const_assert`
-Generally, WGSL elements are included if they are recursively used from the root module ([statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed)).
+Generally, WGSL elements are included if they are recursively used from the entry module ([statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed)).
 An import statement by itself doesn't have any side effects. It does not bring in `const_assert`s.
 
 `const_assert` statements are also included if they are in the same module or namespace as a used element.

--- a/Imports.md
+++ b/Imports.md
@@ -213,8 +213,8 @@ How a package maps module paths to sources depends on how it is stored (see
 [Non-Filesystem Resolution](#non-filesystem-resolution)).
 
 A module path may consist of just `package`, or of just a bare package name.
-Such a path refers to the optional *package module*
-(see [The package module](#the-package-module)).
+Such a path refers to the optional *package root module*
+(see [The package root module](#the-package-root-module)).
 
 Referencing a declaration path that fails to resolve is an error. An import
 statement whose bound name is never referenced is allowed, even if
@@ -270,19 +270,19 @@ determines the declaration path `package::lighting::shadowmapping::pcf`,
 referring to a function `pcf` declared in `lighting/shadowmapping.wesl` (not
 shown).
 
-## The package module
+## The package root module
 
-A package may optionally provide a top-level *package module*: a module named
-`package` at the root of the package's module path, typically from a file or
-resource named `package.wesl`.
+The *package root module* is the optional module which the bare `package`
+module path maps to.
 
-A declaration `fn foo` in the package module is addressable from outside the
+A declaration `foo` in the package root module is addressable from outside the
 package as `my_pkg::foo`, and from within the package as `package::foo`.
 
 A `package` module is only allowed at the top level; tools should warn about a
 module named `package` anywhere else.
 
 ## Filesystem Resolution
+
 On a filesystem, a module path maps directly to a single file, following
 [Resolving a declaration path](#resolving-a-declaration-path). The first
 segment corresponds to the

--- a/Imports.md
+++ b/Imports.md
@@ -274,7 +274,7 @@ shown).
 
 The *package root module* is the optional module that the bare `package`
 module path maps to. In filesystem resolution, it corresponds to a special file
-named `package.json` in the package root directory.
+named `package.wesl` in the package root directory.
 
 A declaration `foo` in the package root module is addressable from outside the
 package as `my_pkg::foo`, and from within the package as `package::foo`.
@@ -287,20 +287,20 @@ module named `package` anywhere else.
 On a filesystem, a module path maps directly to a single file, following
 [Resolving a declaration path](#resolving-a-declaration-path).
 
-The resolution starts with a filesystem root directory, typically in a
+The resolution starts with a package root directory, typically in a
 [`wesl.toml`](WeslToml.md#root-field) file, user-provided through the linker's API,
 or defaulted by the linker.
 
 > [!NOTE]
-> Linkers may apply heuristics to find the default filesystem root directory, such as
+> Linkers may apply heuristics to find the default package root directory, such as
 > looking for a `shaders` directory at the project root, or using the parent directory
 > of the main module.
 
 The package root module path is mapped to a file named `package.wesl` or `package.wgsl`
 in the package root directory.
 
-Other module paths are mapped as follows: each intermediate segment after `package`
- name a subdirectory from the package root directory, and the last segment names
+Other module paths are mapped as follows: each intermediate segment after `package`s
+ names a subdirectory from the package root directory, and the last segment names
 a `.wesl` or `.wgsl` file within the subdirectory.
 
 The `.wesl` extension takes priority over `.wgsl` in case both files are present.
@@ -327,8 +327,8 @@ The filesystem resolution maps:
 
 * `package` to `shaders/package.wesl`
 * `package::main` to `shaders/main.wesl`
-* `package::util` to `shaders/package/util.wgsl`
-* `package::util::noise` to `shaders/package/util/noise.wesl`
+* `package::util` to `shaders/util.wgsl`
+* `package::util::noise` to `shaders/util/noise.wesl`
 * `package::data` is an invalid module path, because there is no file named
   `data.wesl` or `data.wgsl` in `shaders/`.
 

--- a/NameMangling.md
+++ b/NameMangling.md
@@ -14,8 +14,8 @@ See also renaming host visible names in [Visibility](./Visibility.md).
 ## What gets mangled
 All declaration identifiers get mangled, except:
 
-* root module declarations (this is being discussed, see <https://github.com/webgpu-tools/wesl-js/issues/98>)
-* declarations imported in the root module
+* entry module declarations (this is being discussed, see <https://github.com/webgpu-tools/wesl-js/issues/98>)
+* declarations imported in the entry module
   * if the import renames the declaration (using the `import foo as bar` syntax), the declaration is renamed.
   * if the import is a module (`import some::module` where `some/module.wesl` exists) it does not affect mangling.
 

--- a/NameMangling.md
+++ b/NameMangling.md
@@ -14,8 +14,8 @@ See also renaming host visible names in [Visibility](./Visibility.md).
 ## What gets mangled
 All declaration identifiers get mangled, except:
 
-* entry module declarations (this is being discussed, see <https://github.com/webgpu-tools/wesl-js/issues/98>)
-* declarations imported in the entry module
+* main module declarations (this is being discussed, see <https://github.com/webgpu-tools/wesl-js/issues/98>)
+* declarations imported in the main module
   * if the import renames the declaration (using the `import foo as bar` syntax), the declaration is renamed.
   * if the import is a module (`import some::module` where `some/module.wesl` exists) it does not affect mangling.
 

--- a/Visibility.md
+++ b/Visibility.md
@@ -2,7 +2,7 @@
 
 Visibility controls which other modules can reference or re-export an item. For
 entry points, resource variables, and pipeline-overridable constants, it also
-controls which items the entry module exposes to the host.
+controls which items the main module exposes to the host.
 
 Every WESL item has one of three visibility levels:
 
@@ -10,7 +10,7 @@ Every WESL item has one of three visibility levels:
 * *package* (the default): visible from any module in the same package.
 * `private`: visible only within the declaring module.
 
-| Visibility | Cross-module access | [Re-exportable](#a-re-export-cannot-widen-visibility) | Root-declared [pipeline-relevant item](#pipeline-visibility) |
+| Visibility | Cross-module access | [Re-exportable](#a-re-export-cannot-widen-visibility) | Main-declared [pipeline-relevant item](#pipeline-visibility) |
 | --- | --- | --- | --- |
 | `public` | Any package | Yes | Pipeline-visible |
 | *package* (default) | Same package only | No | Pipeline-visible |
@@ -28,9 +28,9 @@ items are visible (see [Wildcard imports](Imports.md#wildcard-imports)).
 > Small applications generally need no visibility keywords. Unmarked items are
 > visible throughout the package, so modules can share helpers and types without
 > additional syntax. Unmarked entry points, resource variables, and overrides
-> declared in the entry module are
+> declared in the main module are
 > [pipeline-visible](#pipeline-visibility), so a plain WGSL program can serve as
-> a WESL root unchanged.
+> a WESL main module unchanged.
 > 
 > Larger applications and libraries can use `private` to keep implementation
 > details within their declaring modules. An item must be `public` to cross a
@@ -96,7 +96,7 @@ struct Mesh { vertices: u32 }            // package-visible (the default)
 public fn make_mesh() -> Mesh { ... }    // returns a package-visible type
 // public alias Exposed = Mesh;          // error: alias more visible than Mesh
 
-// app/main.wesl  (root)
+// app/main.wesl  (main module)
 import mesh_lib::geometry::make_mesh;
 // import mesh_lib::geometry::Mesh;      // error: Mesh is package-visible only
 
@@ -176,16 +176,16 @@ public import super::internal::helper;    // error: helper is package
 
 ## Pipeline visibility
 
-WESL translation starts from a single entry module, which determines the entire
+WESL translation starts from a single main module, which determines the entire
 pipeline-visible API. Only three kinds of items, called *pipeline-relevant
 items*, can be pipeline-visible: **entry points**, **resource variables**, and
 **pipeline-overridable constants**. The pipeline-visible items form the
 host-facing interface of the linked shader.
 
 After [conditional translation](ConditionalTranslation.md), a pipeline-relevant
-item is in the pipeline-visible API when the entry module declares it with
-`public` or *package* visibility, or when the entry module `public import`s it
-from another module. A bare `import` in the entry module brings an item into
+item is in the pipeline-visible API when the main module declares it with
+`public` or *package* visibility, or when the main module `public import`s it
+from another module. A bare `import` in the main module brings an item into
 local scope but does not add it to the pipeline-visible API.
 
 Marking an entry point or resource variable `private` is an error: `private`
@@ -196,22 +196,22 @@ participate in the shader by deriving its value from another override (see
 
 A resource variable or `override`
 [statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed) from the
-entry module's dependency graph but absent from the pipeline-visible API is a
+main module's dependency graph but absent from the pipeline-visible API is a
 link error (except for a defaulted `override`; see below). The check starts from
-declarations in the entry module and follows references transitively.
+declarations in the main module and follows references transitively.
 
 An `import` statement is not itself a static access. After a bound name expands
 to its import path, the resulting reference participates in the static-access
 rules like any other reference.
 
-Pipeline-visible items keep their exposed names in the linked WGSL output. A
-root-declared item keeps its declared name. An item re-exported by
+Pipeline-visible items keep their exposed names in the linked WGSL output.
+A declaration in the main module keeps its name. An item re-exported by
 `public import` keeps its imported name, or its `as` alias if renamed. For
 example, `public import some_pkg::pbr_fragment as my_frag;` exposes `my_frag`.
 Other items may be mangled by the linker.
 
 Libraries cannot directly add to the pipeline-visible API. Instead, libraries
-publish `public` items for the entry module to `public import`.
+publish `public` items for the main module to `public import`.
 
 ### Entry points
 
@@ -225,7 +225,7 @@ or *package*-visible.
 @fragment
 public fn pbr_fragment() -> @location(0) vec4f { ... }
 
-// app/main.wesl  (root)
+// app/main.wesl  (main module)
 public import pbr_lib::passes::pbr_fragment;    // host can select this entry point
 ```
 
@@ -245,10 +245,10 @@ public fn blur(@builtin(global_invocation_id) id: vec3u) {
   data[id.x] = ...;
 }
 
-// app/main.wesl  (root)
+// app/main.wesl  (main module)
 public import filter_wgsl::blur;
 // error: `filter_wgsl::data` is statically accessed but not pipeline-visible
-// fix: add `public import filter_wgsl::data;` to the entry module
+// fix: add `public import filter_wgsl::data;` to the main module
 ```
 
 The `public import` does not create a new resource variable; the original
@@ -270,7 +270,7 @@ expression that depends on an `override` does not satisfy a const-expression
 requirement, even if the linker emits that declaration as a `const`.
 
 A non-defaulted `override` absent from the pipeline-visible API is a link error
-if it is statically accessed from the entry module.
+if it is statically accessed from the main module.
 
 ```wesl
 // pbr_lib/lighting.wesl
@@ -278,7 +278,7 @@ public override sun_intensity: f32 = 1.0;       // has default
 public override max_lights: u32;                // no default
 public fn apply_lighting() -> vec4f { ... }     // uses both overrides
 
-// app/main.wesl  (root)
+// app/main.wesl  (main module)
 import pbr_lib::lighting::apply_lighting;
 public import pbr_lib::lighting::max_lights;    // host must set
 
@@ -293,8 +293,8 @@ fn fragment_main() -> @location(0) vec4f {
 ### Aggregating entry points
 
 It is common to declare an app's entry points in many source files. In this case,
-one can re-export them from a small entry module alongside other pipeline-relevant items.
-The entry points must be declared `public` so the root can re-export them (see
+one can re-export them from a small main module alongside other pipeline-relevant items.
+The entry points must be declared `public` so the main module can re-export them (see
 [A re-export cannot widen visibility](#a-re-export-cannot-widen-visibility)):
 
 ```wesl
@@ -304,7 +304,7 @@ The entry points must be declared `public` so the root can re-export them (see
 // app/fragment.wesl
 @fragment public fn fragment_main(...) -> @location(0) vec4f { ... }
 
-// app/main.wesl  (root)
+// app/main.wesl  (main module)
 public import super::vertex::vertex_main;
 public import super::fragment::fragment_main;
 ```

--- a/Visibility.md
+++ b/Visibility.md
@@ -292,9 +292,9 @@ fn fragment_main() -> @location(0) vec4f {
 
 ### Aggregating entry points
 
-When an app's entry points live in multiple source files, a small entry module
-brings them together. The entry points must be declared `public` so the root can
-re-export them (see
+It is common to declare an app's entry points in many source files. In this case,
+one can re-export them from a small entry module alongside other pipeline-relevant items.
+The entry points must be declared `public` so the root can re-export them (see
 [A re-export cannot widen visibility](#a-re-export-cannot-widen-visibility)):
 
 ```wesl

--- a/Visibility.md
+++ b/Visibility.md
@@ -2,7 +2,7 @@
 
 Visibility controls which other modules can reference or re-export an item. For
 entry points, resource variables, and pipeline-overridable constants, it also
-controls which items the root module exposes to the host.
+controls which items the entry module exposes to the host.
 
 Every WESL item has one of three visibility levels:
 
@@ -28,7 +28,7 @@ items are visible (see [Wildcard imports](Imports.md#wildcard-imports)).
 > Small applications generally need no visibility keywords. Unmarked items are
 > visible throughout the package, so modules can share helpers and types without
 > additional syntax. Unmarked entry points, resource variables, and overrides
-> declared in the root module are
+> declared in the entry module are
 > [pipeline-visible](#pipeline-visibility), so a plain WGSL program can serve as
 > a WESL root unchanged.
 > 
@@ -176,16 +176,16 @@ public import super::internal::helper;    // error: helper is package
 
 ## Pipeline visibility
 
-WESL translation starts from a single root module, which determines the entire
+WESL translation starts from a single entry module, which determines the entire
 pipeline-visible API. Only three kinds of items, called *pipeline-relevant
 items*, can be pipeline-visible: **entry points**, **resource variables**, and
 **pipeline-overridable constants**. The pipeline-visible items form the
 host-facing interface of the linked shader.
 
 After [conditional translation](ConditionalTranslation.md), a pipeline-relevant
-item is in the pipeline-visible API when the root module declares it with
-`public` or *package* visibility, or when the root module `public import`s it
-from another module. A bare `import` in the root module brings an item into
+item is in the pipeline-visible API when the entry module declares it with
+`public` or *package* visibility, or when the entry module `public import`s it
+from another module. A bare `import` in the entry module brings an item into
 local scope but does not add it to the pipeline-visible API.
 
 Marking an entry point or resource variable `private` is an error: `private`
@@ -196,9 +196,9 @@ participate in the shader by deriving its value from another override (see
 
 A resource variable or `override`
 [statically accessed](https://www.w3.org/TR/WGSL/#statically-accessed) from the
-root module's dependency graph but absent from the pipeline-visible API is a
+entry module's dependency graph but absent from the pipeline-visible API is a
 link error (except for a defaulted `override`; see below). The check starts from
-declarations in the root module and follows references transitively.
+declarations in the entry module and follows references transitively.
 
 An `import` statement is not itself a static access. After a bound name expands
 to its import path, the resulting reference participates in the static-access
@@ -211,7 +211,7 @@ example, `public import some_pkg::pbr_fragment as my_frag;` exposes `my_frag`.
 Other items may be mangled by the linker.
 
 Libraries cannot directly add to the pipeline-visible API. Instead, libraries
-publish `public` items for the root module to `public import`.
+publish `public` items for the entry module to `public import`.
 
 ### Entry points
 
@@ -248,7 +248,7 @@ public fn blur(@builtin(global_invocation_id) id: vec3u) {
 // app/main.wesl  (root)
 public import filter_wgsl::blur;
 // error: `filter_wgsl::data` is statically accessed but not pipeline-visible
-// fix: add `public import filter_wgsl::data;` to the root module
+// fix: add `public import filter_wgsl::data;` to the entry module
 ```
 
 The `public import` does not create a new resource variable; the original
@@ -270,7 +270,7 @@ expression that depends on an `override` does not satisfy a const-expression
 requirement, even if the linker emits that declaration as a `const`.
 
 A non-defaulted `override` absent from the pipeline-visible API is a link error
-if it is statically accessed from the root module.
+if it is statically accessed from the entry module.
 
 ```wesl
 // pbr_lib/lighting.wesl
@@ -292,7 +292,7 @@ fn fragment_main() -> @location(0) vec4f {
 
 ### Aggregating entry points
 
-When an app's entry points live in multiple source files, a small root module
+When an app's entry points live in multiple source files, a small entry module
 brings them together. The entry points must be declared `public` so the root can
 re-export them (see
 [A re-export cannot widen visibility](#a-re-export-cannot-widen-visibility)):

--- a/VisibilityDesign.md
+++ b/VisibilityDesign.md
@@ -23,7 +23,7 @@ normative spec lives in [Visibility.md](Visibility.md).
   * [`package` keyword on declarations](#package-keyword-on-declarations)
   * [Module re-export](#module-re-export)
   * [Canonical prelude path](#canonical-prelude-path)
-  * [Re-export widening from root](#re-export-widening-from-root)
+  * [Re-export widening from main](#re-export-widening-from-main)
   * [Wildcard re-export](#wildcard-re-export)
   * [Member visibility](#member-visibility)
   * [Diagnosing less-visible types in public
@@ -94,17 +94,17 @@ requires an explicit visibility marker. Encapsulation discipline by default is
 handy for larger teams working on larger codebases. But private by default
 wouldn't work as well for WESL for a few reasons:
 
-* **Module entry points would need explicit markers.** The entry module's
+* **Module entry points would need explicit markers.** The main module's
   entry points, resource variables, and overrides reach the host only when
   non-private (see [Visibility.md](Visibility.md)). With private as the default,
   every one would need a visibility marker. With package as the default,
-  `@fragment fn frag_main(...)` at root is pipeline-visible with no extra
+  `@fragment fn frag_main(...)` in the main module is pipeline-visible with no extra
   keywords or annotations.
 
   WESL features are also designed for possible adoption into WGSL. A private
   default would make existing, unmarked WGSL entry points and overrides
   invisible to the host. Avoiding that incompatibility would require separate
-  defaults or visibility rules for the entry module. Package visibility avoids that
+  defaults or visibility rules for the main module. Package visibility avoids that
   special case.
 
 * **WGSL compatibility would be awkward.** WGSL has no visibility keywords. With
@@ -244,13 +244,13 @@ WESL tools could not reliably find or update them when that name changes.
 
 Instead, WESL keeps each boundary explicit. A library can use a `public` item
 from a dependency with a bare `import` without passing it on, or re-export it
-with a `public import`. The entry module makes a separate choice for the host: it
+with a `public import`. The main module makes a separate choice for the host: it
 exposes its non-private pipeline-relevant items directly and selected library
 items through `public import`. This lets each application and library decide
 which dependency items cross its own API boundary.
 
-This design requires the entry module to name exposed items explicitly. A small
-program may declare them in the entry module; a larger program can expose items
+This design requires the main module to name exposed items explicitly. A small
+program may declare them in the main module; a larger program can expose items
 from other modules with `public import`.
 
 ## Future possibilities
@@ -284,16 +284,16 @@ the original path) without any change to name resolution. Stronger designs that
 make the original path unreachable (module visibility controls) are collected in
 [#202](https://github.com/webgpu-tools/wesl-spec/issues/202).
 
-### Re-export widening from root
+### Re-export widening from main
 
-A plain `.wgsl` file with an entry point cannot be aggregated into an entry module
+A plain `.wgsl` file with an entry point cannot be aggregated into a main module
 via `public import` without modification (see
 [Aggregating entry points](Visibility.md#aggregating-entry-points)). A
-relaxation would let the entry module `public import` *package* items from the
-same package, since the root already chooses the pipeline-visible API. The cost
+relaxation would let the main module `public import` *package* items from the
+same package, since the main module already chooses the pipeline-visible API. The cost
 is loss of orthogonality: what `public import` accepts would depend on whether
-the importer is the root. Root status belongs to a link invocation, not to the
-module itself; the same module can be a root in one link and an ordinary module
+the importer is the main module. Determination of the main module belongs to a link invocation, not to the
+module itself; the same module can be main in one link and an ordinary module
 in another. Source-only tools such as the language server could not check that
 rule without knowing how the module will be linked.
 

--- a/VisibilityDesign.md
+++ b/VisibilityDesign.md
@@ -94,7 +94,7 @@ requires an explicit visibility marker. Encapsulation discipline by default is
 handy for larger teams working on larger codebases. But private by default
 wouldn't work as well for WESL for a few reasons:
 
-* **Root module entry points would need explicit markers.** A root module's
+* **Module entry points would need explicit markers.** The entry module's
   entry points, resource variables, and overrides reach the host only when
   non-private (see [Visibility.md](Visibility.md)). With private as the default,
   every one would need a visibility marker. With package as the default,
@@ -104,7 +104,7 @@ wouldn't work as well for WESL for a few reasons:
   WESL features are also designed for possible adoption into WGSL. A private
   default would make existing, unmarked WGSL entry points and overrides
   invisible to the host. Avoiding that incompatibility would require separate
-  defaults or visibility rules for root modules. Package visibility avoids that
+  defaults or visibility rules for the entry module. Package visibility avoids that
   special case.
 
 * **WGSL compatibility would be awkward.** WGSL has no visibility keywords. With
@@ -244,13 +244,13 @@ WESL tools could not reliably find or update them when that name changes.
 
 Instead, WESL keeps each boundary explicit. A library can use a `public` item
 from a dependency with a bare `import` without passing it on, or re-export it
-with a `public import`. The root module makes a separate choice for the host: it
+with a `public import`. The entry module makes a separate choice for the host: it
 exposes its non-private pipeline-relevant items directly and selected library
 items through `public import`. This lets each application and library decide
 which dependency items cross its own API boundary.
 
-This design requires the root module to name exposed items explicitly. A small
-program may declare them in the root module; a larger program can expose items
+This design requires the entry module to name exposed items explicitly. A small
+program may declare them in the entry module; a larger program can expose items
 from other modules with `public import`.
 
 ## Future possibilities
@@ -286,10 +286,10 @@ make the original path unreachable (module visibility controls) are collected in
 
 ### Re-export widening from root
 
-A plain `.wgsl` file with an entry point cannot be aggregated into a root module
+A plain `.wgsl` file with an entry point cannot be aggregated into an entry module
 via `public import` without modification (see
 [Aggregating entry points](Visibility.md#aggregating-entry-points)). A
-relaxation would let the root module `public import` *package* items from the
+relaxation would let the entry module `public import` *package* items from the
 same package, since the root already chooses the pipeline-visible API. The cost
 is loss of orthogonality: what `public import` accepts would depend on whether
 the importer is the root. Root status belongs to a link invocation, not to the

--- a/VisibilityDesign.md
+++ b/VisibilityDesign.md
@@ -94,7 +94,7 @@ requires an explicit visibility marker. Encapsulation discipline by default is
 handy for larger teams working on larger codebases. But private by default
 wouldn't work as well for WESL for a few reasons:
 
-* **Module entry points would need explicit markers.** The main module's
+* **Main module entry points would need explicit markers.** The main module's
   entry points, resource variables, and overrides reach the host only when
   non-private (see [Visibility.md](Visibility.md)). With private as the default,
   every one would need a visibility marker. With package as the default,

--- a/WeslToml.md
+++ b/WeslToml.md
@@ -68,7 +68,7 @@ For dual publishing, the expectation is that one would have a primary package ma
 
 ### `root` field
 
-Specifies the root folder for the `package::` syntax.
+Specifies the package root directory for the [filesystem resolution](Imports.md#filesystem-resolution).
 IDEs watch this directory for changes.
 
 - Optional


### PR DESCRIPTION
Per our [Discord discussion](https://discord.com/channels/1275293995152703488/1275318205530898503/1529192881880043704) I clarify the meaning of root module which was confused with package root directory and `package::` module path. I also went ahead and tweaked the glossary.

* renamed root module -> entry module.
* removed wesl translator which was a bit redundant with wesl linker.
* tweaked and moved other definitions.